### PR TITLE
player controlls disabled when console opened

### DIFF
--- a/Assets/Plugins/QFSW/Quantum Console/Source/Prefabs/Default Key Config.asset
+++ b/Assets/Plugins/QFSW/Quantum Console/Source/Prefabs/Default Key Config.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   SubmitCommandKey: 13
   ShowConsoleKey:
-    Key: 282
+    Key: 0
     Ctrl: 0
     Alt: 0
     Shift: 0
@@ -24,7 +24,7 @@ MonoBehaviour:
     Alt: 0
     Shift: 0
   ToggleConsoleVisibilityKey:
-    Key: 27
+    Key: 282
     Ctrl: 0
     Alt: 0
     Shift: 0

--- a/Assets/Scripts/Entity/Player.cs
+++ b/Assets/Scripts/Entity/Player.cs
@@ -7,7 +7,7 @@ using QFSW.QC;
 
 namespace Assets.Scripts.Entity
 {
-
+    
     [CommandPrefix("Entity.Player.")]
     [RequireComponent(typeof(AudioSource))]
     public class Player : AbstractEntity
@@ -23,6 +23,12 @@ namespace Assets.Scripts.Entity
         private Vector2 _spawnPoint;
 
         [SerializeField] private PlayerAudioPlayer _audio;
+        private QuantumConsole _console;
+
+        /// <summary>
+        /// If true the user will not be able to control the player
+        /// </summary>
+        private bool _controlsDisabled = false;
 
         new public void Start()
         {
@@ -32,19 +38,26 @@ namespace Assets.Scripts.Entity
             _spawnPoint = transform.position;
 
             _audio.Source = GetComponent<AudioSource>();
+            _console = FindObjectOfType<QuantumConsole>();
+            
+            _console.OnActivate += () => { _controlsDisabled = true; }; // Disable player controls when console gets activated
+            _console.OnDeactivate += () => { _controlsDisabled = false; }; // Enable player controls when console gets closed
         }
 
         public void FixedUpdate()
         {
-            Movement = new Vector2(Input.GetAxisRaw("Horizontal"), 0);
-            /**
-             * ##### Why GetButton got replaced with GetKey #####
-             * For some reason GetButton is unreliable and won't always register the key pressed
-             */
-            if (Input.GetKey(KeyCode.Space) && RB.velocity.y == 0)
+            if (!_controlsDisabled)
             {
-                RB.velocity = Vector2.up * JumpVelocity;
-                _audio.Play(_audio.Jump);
+                Movement = new Vector2(Input.GetAxisRaw("Horizontal"), 0);
+                /**
+                 * ##### Why GetButton got replaced with GetKey #####
+                 * For some reason GetButton is unreliable and won't always register the key pressed
+                 */
+                if (Input.GetKey(KeyCode.Space) && RB.velocity.y == 0)
+                {
+                    RB.velocity = Vector2.up * JumpVelocity;
+                    _audio.Play(_audio.Jump);
+                }
             }
 
             if (RB.velocity.x > _maxVelocity.x)


### PR DESCRIPTION
The player should not be able to interact with the world while console is opened